### PR TITLE
ShibIntIdP: VhrBasicAuthFilter: fix logger name

### DIFF
--- a/shibboleth-integration/src/aaf/vhr/idp/http/VhrBasicAuthFilter.java
+++ b/shibboleth-integration/src/aaf/vhr/idp/http/VhrBasicAuthFilter.java
@@ -24,7 +24,7 @@ public class VhrBasicAuthFilter implements Filter {
   private String realm;
   private VhrBasicAuthValidator vhrBasicAuthValidator;
 
-  Logger log = LoggerFactory.getLogger("aaf.vhr.idp.http.VhrFilter");
+  Logger log = LoggerFactory.getLogger("aaf.vhr.idp.http.VhrBasicAuthFilter");
 
   @Override
   public void destroy() {


### PR DESCRIPTION
... accidentally, the VhrBasicAuthFilter class was requesting a logger
for aaf.vhr.idp.http.VhrFilter ...
