### PR TITLE
LostUsernameController: handle accounts without a username

### DIFF
--- a/virtualhome/src/groovy/aaf/vhr/email_lost_username.gsp
+++ b/virtualhome/src/groovy/aaf/vhr/email_lost_username.gsp
@@ -21,7 +21,7 @@ If you did not request your username please contact support@aaf.edu.au immediate
   <h5>Your account does not have a usernamet yet.</h5>
 
   This may be because you have not finalized your account invite.  If you cannot find the original email with the account invite, please contact support@aaf.edu.au to request having the account invite sent again.
-</g:else>
+  </g:else>
 </g:if>
 <g:else>
   <h5>Your email address is not associated with an account in AAF Virtual Home.</h5>

--- a/virtualhome/src/groovy/aaf/vhr/email_lost_username.gsp
+++ b/virtualhome/src/groovy/aaf/vhr/email_lost_username.gsp
@@ -18,7 +18,7 @@ If you did not request your username please contact support@aaf.edu.au immediate
   If you have also lost your password, you may initiate a password reset using the <strong>Recover your lost password</strong> link on the AAF Virtual Home login page.
   </g:if>
   <g:else>
-  <h5>Your account does not have a usernamet yet.</h5>
+  <h5>Your account does not have a username yet.</h5>
 
   This may be because you have not finalized your account invite.  If you cannot find the original email with the account invite, please contact support@aaf.edu.au to request having the account invite sent again.
   </g:else>

--- a/virtualhome/src/groovy/aaf/vhr/email_lost_username.gsp
+++ b/virtualhome/src/groovy/aaf/vhr/email_lost_username.gsp
@@ -10,11 +10,18 @@ We have received a request to provide the username you use for logging in to the
 If you did not request your username please contact support@aaf.edu.au immediately, providing your account details and a copy of this notification.<br><br>
 
 <g:if test="${managedSubject}">
+  <g:if test="${managedSubject.login}">
   <h5>Your username is:</h5>
 
   ${managedSubject.login.encodeAsHTML()}<br><br>
 
   If you have also lost your password, you may initiate a password reset using the <strong>Recover your lost password</strong> link on the AAF Virtual Home login page.
+  </g:if>
+  <g:else>
+  <h5>Your account does not have a usernamet yet.</h5>
+
+  This may be because you have not finalized your account invite.  If you cannot find the original email with the account invite, please contact support@aaf.edu.au to request having the account invite sent again.
+</g:else>
 </g:if>
 <g:else>
   <h5>Your email address is not associated with an account in AAF Virtual Home.</h5>


### PR DESCRIPTION
Fixes #210 - checks for null managedSubject.login and includes a
customized error message.