### PR TITLE
Force collections update

### DIFF
--- a/virtualhome/grails-app/conf/BuildConfig.groovy
+++ b/virtualhome/grails-app/conf/BuildConfig.groovy
@@ -26,14 +26,17 @@ grails.project.dependency.resolution = {
     mavenLocal()
     mavenCentral()
 
+    mavenRepo "http://repo.grails.org/grails/plugins-releases/"
     mavenRepo "http://repo.grails.org/grails/repo/"
     mavenRepo "http://download.java.net/maven/2/"
     mavenRepo "http://repository.jboss.com/maven2/"
   }
 
   dependencies {
-    test 'mysql:mysql-connector-java:5.1.18'
+    compile "commons-collections:commons-collections:3.2.2"
     compile "com.google.guava:guava:14.0"
+
+    test 'mysql:mysql-connector-java:5.1.18'
   }
 
   /*

--- a/virtualhome/test/unit/aaf/vhr/LostPasswordControllerSpec.groovy
+++ b/virtualhome/test/unit/aaf/vhr/LostPasswordControllerSpec.groovy
@@ -7,6 +7,7 @@ import grails.buildtestdata.mixin.Build
 import spock.lang.*
 
 import aaf.base.identity.*
+import aaf.base.SMSDeliveryService
 
 @TestFor(aaf.vhr.LostPasswordController)
 @Build([aaf.vhr.Organization, aaf.vhr.Group, aaf.vhr.ManagedSubject, aaf.base.admin.EmailTemplate, aaf.base.identity.Subject, aaf.base.identity.Role, aaf.vhr.switchch.vho.DeprecatedSubject])
@@ -28,7 +29,7 @@ class LostPasswordControllerSpec extends spock.lang.Specification {
     emailManagerService = Mock(aaf.base.EmailManagerService)
     controller.emailManagerService = emailManagerService
 
-    smsDeliveryService = Mock(aaf.base.SMSDeliveryService)
+    smsDeliveryService = Mock(SMSDeliveryService)
     controller.smsDeliveryService = smsDeliveryService
   }
 


### PR DESCRIPTION
Update VH to remove Apache commons collections version that may be
vulnerable to "Mad Gadget"

https://opensource.googleblog.com/2017/03/operation-rosehub.html
https://www.kb.cert.org/vuls/id/576313

We believe that Grails was never directly impacted
http://stackoverflow.com/questions/41946971/grails-apache-commons-collection-vulnerability
but the most recent Google discussion does state "Mad Gadget is one of
the most pernicious vulnerabilities we’ve seen. By merely existing on the
Java classpath, seven “gadget” classes in Apache Commons Collections
(versions 3.0, 3.1, 3.2, 3.2.1, and 4.0) make object deserialization for
the entire JVM process Turing complete with an exec function."

Good enough for me and by the extension the AAF, to force this update.

All VH tests have passed here. In addition a war built from this set of commits now correctly shows:

…
WEB-INF/lib/commons-codec-1.5.jar
WEB-INF/lib/commons-collections-3.2.2.jar
WEB-INF/lib/commons-dbcp-1.4.jar
…

I believe this is solid enough to cut and build 1.4.1-rc1 for deployment to the AAF test federation immediately following this PR merge.