### PR TITLE
Login: make cookies httpOnly besides being secure

### DIFF
--- a/virtualhome/grails-app/controllers/aaf/vhr/LoginController.groovy
+++ b/virtualhome/grails-app/controllers/aaf/vhr/LoginController.groovy
@@ -227,6 +227,7 @@ class LoginController {
     Cookie cookie = new Cookie(LoginService.SSO_COOKIE_NAME, sessionID)
     cookie.maxAge = maxAge
     cookie.secure = grailsApplication.config.aaf.vhr.login.ssl_only_cookie
+    cookie.httpOnly = true
     cookie.path = grailsApplication.config.aaf.vhr.login.path
     response.addCookie(cookie)
 

--- a/virtualhome/grails-app/services/aaf/vhr/LoginService.groovy
+++ b/virtualhome/grails-app/services/aaf/vhr/LoginService.groovy
@@ -129,6 +129,7 @@ class LoginService implements InitializingBean{
     Cookie cookie = new Cookie(LoginService.TWOSTEP_COOKIE_NAME, twoStepSession.value)
     cookie.maxAge = maxAge
     cookie.secure = grailsApplication.config.aaf.vhr.login.ssl_only_cookie
+    cookie.httpOnly = true
     cookie.path = grailsApplication.config.aaf.vhr.login.path
     response.addCookie(cookie)
 


### PR DESCRIPTION
To prevent the cookies being stolen by malicious browser-side scripts.
(future-proofing in case a XSS vulnerability ever gets through)

@bradleybeddoes - happy to merge this?  All tests passing.