### PR TITLE
Remove login form logos

### DIFF
--- a/virtualhome/grails-app/views/login/index.gsp
+++ b/virtualhome/grails-app/views/login/index.gsp
@@ -26,21 +26,6 @@
             <li>Better security for your users. Password resets use one time codes instead of having you set something on their behalf; and</li>
             <li>The ability to manage many more groups and users than was previously possible.</li>
           </ul>
-
-          <br><br>
-          <center>
-            <p>
-              <img src="https://s3-ap-southeast-2.amazonaws.com/aaf-assets/virtualhome/login-page/aero-logo.png"
-                   alt="Member of the Australasian eResearch Organisations"
-                   width="400" height="80"/>
-            </p>
-            <p>&nbsp;</p>
-            <p>
-              <img src="https://s3-ap-southeast-2.amazonaws.com/aaf-assets/virtualhome/login-page/caudit-logo.png"
-                   alt="Supported by the Council of Australasian University Directors of Information Technology"
-                   width="400" height="80"/>
-            </p>
-          </center>
         </div>
 
         <div id="loginform" class="span5 offset1">


### PR DESCRIPTION
There's been a change of plan since #214. Nice and clean, isn't it?

![image](https://user-images.githubusercontent.com/6358/31406501-ebbcfb5c-ae44-11e7-8ded-6ebb8d06b260.png)
