### PR TITLE
Login: disable autocomplete for TOTP fields

### DIFF
--- a/virtualhome/grails-app/views/account/enabletwostep.gsp
+++ b/virtualhome/grails-app/views/account/enabletwostep.gsp
@@ -33,7 +33,7 @@
               <div class="control-group">
                 <label class="control-label" for="totp"><g:message code="label.2stepcode"/></label>
                 <div class="controls">
-                  <input id="totp" name="totp" type="text" autofocus="autofocus" class="required"/>
+                  <input id="totp" name="totp" type="text" autofocus="autofocus" class="required" autocomplete="off"/>
                 </div>
               </div>
 

--- a/virtualhome/grails-app/views/account/twostep.gsp
+++ b/virtualhome/grails-app/views/account/twostep.gsp
@@ -22,7 +22,7 @@
               <div class="control-group">
                 <label class="control-label" for="totp"><g:message code="label.2stepcode"/></label>
                 <div class="controls">
-                  <input id="totp" name="totp" type="text" autofocus="autofocus" class="required"/>
+                  <input id="totp" name="totp" type="text" autofocus="autofocus" class="required" autocomplete="off"/>
                 </div>
               </div>
 

--- a/virtualhome/grails-app/views/login/completesetuptwostep.gsp
+++ b/virtualhome/grails-app/views/login/completesetuptwostep.gsp
@@ -38,7 +38,7 @@
             <div class="control-group">
               <label class="control-label" for="totp"><g:message code="label.2stepcode"/></label>
               <div class="controls">
-                <input id="totp" name="totp" type="text" autofocus="autofocus" class="required"/>
+                <input id="totp" name="totp" type="text" autofocus="autofocus" class="required" autocomplete="off"/>
               </div>
             </div>
 

--- a/virtualhome/grails-app/views/login/twostep.gsp
+++ b/virtualhome/grails-app/views/login/twostep.gsp
@@ -23,7 +23,7 @@
                 <div class="control-group">
                   <label class="control-label" for="totp"><g:message code="label.2stepcode"/></label>
                   <div class="controls">
-                    <input id="totp" name="totp" type="text" autofocus="autofocus" class="required"/>
+                    <input id="totp" name="totp" type="text" autofocus="autofocus" class="required" autocomplete="off"/>
                   </div>
                 </div>
 


### PR DESCRIPTION
Browser try with autocomplete by default - but this does not make sense
at all with the 2FA (TOTP) fields.

Browsers just unneccesarily store the past (no longer valid) values and
confusingly offer these to the user.

End this and hint the browsers with autocomplete="off".