### PR TITLE
Update to recaptcha v2

### DIFF
--- a/virtualhome/grails-app/conf/BuildConfig.groovy
+++ b/virtualhome/grails-app/conf/BuildConfig.groovy
@@ -54,7 +54,7 @@ grails.project.dependency.resolution = {
   */
   plugins {
     compile ":csv:0.3.1"
-    compile ":recaptcha:0.6.4"
+    compile ":recaptcha:1.2.0"
     compile ":jasypt-encryption:1.1.0"
   }
 }

--- a/virtualhome/grails-app/views/_loginform.gsp
+++ b/virtualhome/grails-app/views/_loginform.gsp
@@ -25,18 +25,11 @@
       
       <g:if test="${requiresChallenge}">
         <div class="control-group">
-          <label class="control-label"><g:message code="label.challengeresponse"/></label>
           <div class="controls">
             <recaptcha:ifEnabled>
               <recaptcha:recaptcha theme="white" class="required"/>
             </recaptcha:ifEnabled>
-            <p>
-              <small>
-                <g:message code="templates.aaf.vhr.loginform.challengeresponse.help"/>
-              </small>
-            </p>
           </div>
-          
         </div>
         <br>
       </g:if>

--- a/virtualhome/grails-app/views/lostUsername/start.gsp
+++ b/virtualhome/grails-app/views/lostUsername/start.gsp
@@ -25,20 +25,12 @@
         </div>
       </div>
 
-      <hr>
-
       <div class="control-group">
-        <label class="control-label" for="plainPassword">Challenge Question</label><br>
         <div class="controls">
           <div class="span5">
             <recaptcha:ifEnabled>
               <recaptcha:recaptcha theme="white"/>
             </recaptcha:ifEnabled>
-          </div>
-          <div class="span4">
-            <span class="help-block">
-              <p>Please enter the two words shown at the left so we can ensure you're a real person and not an automated bot.</p>
-            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
As recaptcha v1 has been deprecated requests which required this functionality failed completely.

Our old version of Grails is still very problematic here but I was able to get the recaptcha plugin updated and working for the v2 API, albeit not the latest version of the plugin which is Grails 2.3+ only.

I've tested that this functions correctly on both lost username and multiple failed logins.