### PR TITLE
Views/Org: make org.description not required

### DIFF
--- a/virtualhome/grails-app/views/organization/_form.gsp
+++ b/virtualhome/grails-app/views/organization/_form.gsp
@@ -27,7 +27,7 @@
   <div class="control-group ${hasErrors(bean: organizationInstance, field: 'description', 'error')}">
     <label class="control-label" for="description"><g:message encodeAs='HTML' code="label.description"/></label>
     <div class="controls">
-      <g:textArea name="description" required="" cols="40" rows="5" maxlength="2000" value="${organizationInstance?.description}"/>
+      <g:textArea name="description" cols="40" rows="5" maxlength="2000" value="${organizationInstance?.description}"/>
       <a href="#" rel="tooltip" title="${g.message(encodeAs:'HTML', code:'help.inline.aaf.vhr.organization.description')}"><i class="icon icon-question-sign"></i></a>
     </div>
   </div>


### PR DESCRIPTION
As per https://github.com/ausaccessfed/federationregistry/issues/250
solve the issue presented there by making org.description not required.

Given that the VHO domain model for Organization allows description to be null (`nullable: true`), I see it as typo to mark the form field as `required` - so a tiny PR to drop the `required` flag from the form field.

@bradleybeddoes , OK with you to merge?

Successfully tested and it has the desired effect: allows saving a change to an Organization inside the VHO (such as setting scope) without having to fill in the description.

Cheers,
Vlad