### PR TITLE
Fix NPE when captcha required but not provided

### DIFF
--- a/virtualhome/grails-app/controllers/aaf/vhr/AccountController.groovy
+++ b/virtualhome/grails-app/controllers/aaf/vhr/AccountController.groovy
@@ -40,7 +40,8 @@ class AccountController {
     if(!validPassword) {
       log.info "LoginService indicates failure for password login by $managedSubjectInstance to myaccount"
       session.setAttribute(CURRENT_USER, managedSubjectInstance.id)
-      render view:'index', model:[loginError:true, requiresChallenge:managedSubjectInstance.requiresLoginCaptcha()]
+      def failedCaptcha = managedSubjectInstance.stateChanges?.sort{it.dateCreated}?.last()?.event == StateChangeType.FAILCAPTCHA
+      render view:'index', model:[loginError: !failedCaptcha, loginWarning: failedCaptcha, requiresChallenge:managedSubjectInstance.requiresLoginCaptcha()]
       return
     }
 

--- a/virtualhome/grails-app/controllers/aaf/vhr/LoginController.groovy
+++ b/virtualhome/grails-app/controllers/aaf/vhr/LoginController.groovy
@@ -42,7 +42,8 @@ class LoginController {
       if(managedSubjectInstance) {
         log.debug "FAILED_USER is set for $managedSubjectInstance indicating previous failure. Rendering default login screen."
         session.removeAttribute(FAILED_USER)
-        return [loginError:true, requiresChallenge:managedSubjectInstance.requiresLoginCaptcha()]
+        def failedCaptcha = managedSubjectInstance.stateChanges?.sort{it.dateCreated}?.last()?.event == StateChangeType.FAILCAPTCHA
+        return [loginError: !failedCaptcha, loginWarning: failedCaptcha, requiresChallenge:managedSubjectInstance.requiresLoginCaptcha()]
       }
     }
   }

--- a/virtualhome/grails-app/i18n/messages.properties
+++ b/virtualhome/grails-app/i18n/messages.properties
@@ -273,6 +273,8 @@ templates.aaf.vhr.manageadministrators.group.role.members.none=There are current
 templates.aaf.vhr.loginform.title=Login
 templates.aaf.vhr.loginform.alert=<p><strong>Unable to validate account or password</strong></p> \
           <p>Please try again or use the account help links below.</p>
+templates.aaf.vhr.loginform.captcha-warning=<p><strong>CAPTCHA response missing but required to proceed</strong></p> \
+          <p>Please try again and also answer the CAPTCHA question on the login form.</p>
 templates.aaf.vhr.loginform.challengeresponse.help=Due to repeated errors please provide the above challenge response answers <strong>in addition to your username and password</strong> so we can validate your account.
 templates.aaf.vhr.loginform.help.howelse=How else can we help?
 templates.aaf.vhr.loginform.help.myaccount=View your <a href="/myaccount">account details</a> or <a href="/myaccount">change your password</a>

--- a/virtualhome/grails-app/views/_loginform.gsp
+++ b/virtualhome/grails-app/views/_loginform.gsp
@@ -8,6 +8,12 @@
       </div>
     </g:if>
 
+    <g:if test="${loginWarning}">
+      <div class="alert alert-block alert-warning login-warning">
+        <g:message code="templates.aaf.vhr.loginform.captcha-warning"/>
+      </div>
+    </g:if>
+
     <fieldset>
       <div class="control-group">
         <label class="control-label" for="username"><g:message code="label.username"/></label>


### PR DESCRIPTION
Fixes #222

Temporary workaround for NPE when captcha is required but g-recaptcha-response is not provided in params.

This issue is fixed in recaptcha plugin 1.7.0, but version 1.7.0 would require Grails 2.4,
so we are instead doing this interim workaround (exposing details of the recaptcha plugin)