### PR TITLE
MyAccount/Password change: a few minor fixes

### DIFF
--- a/virtualhome/grails-app/controllers/aaf/vhr/AccountController.groovy
+++ b/virtualhome/grails-app/controllers/aaf/vhr/AccountController.groovy
@@ -153,7 +153,7 @@ class AccountController {
         log.error "New password is invalid for $managedSubjectInstance"
 
         flash.type = 'error'
-        flash.message = 'controllers.aaf.vhr.account.completedetailschange.password.invalid'
+        flash.message = 'controllers.aaf.vhr.account.completedetailschange.new.password.invalid'
         render view: 'changedetails', model: [managedSubjectInstance:managedSubjectInstance]
 
         return

--- a/virtualhome/grails-app/i18n/messages.properties
+++ b/virtualhome/grails-app/i18n/messages.properties
@@ -304,6 +304,10 @@ templates.aaf.vhr.passwordinput.password.requirements=        <p>The AAF has <st
           <li>At least 1 lowercase character; and</li> \
           <li>No whitespace.</li> \
         </ul> \
+        <p>If you choose a password of at least 16 characters in length, only <strong>the following requirement</strong> applies:</p> \
+        <ul> \
+          <li>Does not contain your username;</li> \
+        </ul> \
 
 ###### CONTROLLERS
 controllers.aaf.vhr.group.licensing.failed=This Organisation is limited in how many groups it can create as part of its subscription package. This limit has been exceeded preventing new groups from being created. Please contact AAF support for help in modifying your subscription package to increase this limit.

--- a/virtualhome/grails-app/services/aaf/vhr/PasswordValidationService.groovy
+++ b/virtualhome/grails-app/services/aaf/vhr/PasswordValidationService.groovy
@@ -48,7 +48,7 @@ class PasswordValidationService {
     }
 
     if(subject.plainPassword.toLowerCase().contains(subject.login.toLowerCase())) {
-      log.warn("The submitted plaintext passwords for $subject don't match, rejecting.")
+      log.warn("The submitted plaintext passwords for $subject contains the username, rejecting.")
       subject.errors.rejectValue('plainPassword', 'aaf.vhr.passwordvalidationservice.containslogin')
       subject.discard()
       return [false, ['aaf.vhr.passwordvalidationservice.containslogin'], subject]

--- a/virtualhome/test/unit/aaf/vhr/AccountControllerSpec.groovy
+++ b/virtualhome/test/unit/aaf/vhr/AccountControllerSpec.groovy
@@ -178,7 +178,7 @@ class AccountControllerSpec extends spock.lang.Specification {
     1 * passwordValidationService.validate(_ as ManagedSubject) >>> [[false, ['some.error', 'some.other.error']]]
 
     flash.type == 'error'
-    flash.message == 'controllers.aaf.vhr.account.completedetailschange.password.invalid'
+    flash.message == 'controllers.aaf.vhr.account.completedetailschange.new.password.invalid'
     view == '/account/changedetails'
     model.managedSubjectInstance == managedSubjectTestInstance
   }


### PR DESCRIPTION
Hi @bradleybeddoes ,

I have received a support request to clarify the wording of the password requirement for 16+ character password (only "MUST not contain username" applies) and while looking into it, I found a few more issues in the code:
* AccountController was returning incorrect message code - so users were seeing the message code (`controllers.aaf.vhr.account.completedetailschange.password.invalid`) instead of the actual message (` Your password did not meet the requirements. `)
* The internal log message logged when the password contained the username was incorrectly saying `"The submitted plaintext passwords for $subject don't match, rejecting."` (copied from another check just above).

I have already merged this into my master branch and I'm running it on virtualhome.dev.tuakiri.ac.nz (and likely to be pushed soon to Staging and PROD).

Would you be happy to merge this into your code as well?

Cheers,
Vlad